### PR TITLE
Fix 'make: warning: jobserver unavailable: using -j1'

### DIFF
--- a/analyzer/codechecker_analyzer/buildlog/build_manager.py
+++ b/analyzer/codechecker_analyzer/buildlog/build_manager.py
@@ -41,7 +41,8 @@ def execute_buildcmd(command, silent=False, env=None, cwd=None):
         shell=True,
         universal_newlines=True,
         encoding="utf-8",
-        errors="ignore")
+        errors="ignore",
+        close_fds=False)
 
     while True:
         line = proc.stdout.readline()

--- a/bin/CodeChecker
+++ b/bin/CodeChecker
@@ -55,7 +55,8 @@ def run_codechecker(checker_env, subcommand=None):
     proc = subprocess.Popen(checker_cmd,
                             encoding="utf=8",
                             errors="ignore",
-                            env=checker_env)
+                            env=checker_env,
+                            close_fds=False)
     global proc_pid
     proc_pid = proc.pid
 


### PR DESCRIPTION
Fix for issue 'gmake[1]: warning: jobserver unavailable: using -j1. Add `+' to parent make rule.', which leads to a single thread build. It happens in the following call sequence: [make -j32] -> [bash_script.sh] -> [CodeChecker log -o "$tmp_log" -b "$make_cmd"] -> [make].
Adding the 'close_fds=False' argument to 'subprocess.Popen' avoids closing the file descriptors needed for make jobserver.